### PR TITLE
Hide non GStreamer symbols

### DIFF
--- a/subprojects/opus.wrap
+++ b/subprojects/opus.wrap
@@ -2,6 +2,7 @@
 directory=opus
 url=https://gitlab.xiph.org/xiph/opus.git
 revision=6b6035ae4a29abbd237463d84a45fbeb0d92bc18
+diff_files = opus/0001-meson-Fix-symbol-leaks-on-Windows.patch
 
 [provide]
 opus=opus_dep

--- a/subprojects/orc.wrap
+++ b/subprojects/orc.wrap
@@ -3,6 +3,7 @@ directory=orc
 url=https://gitlab.freedesktop.org/gstreamer/orc.git
 push-url=git@gitlab.freedesktop.org:gstreamer/orc.git
 revision=0.4.38
+diff_files = orc-0.4.38/0001-meson-fix-symbols-leaking-from-static-library-on-Win.patch
 
 [provide]
 orc-0.4 = orc_dep

--- a/subprojects/packagefiles/opus/0001-meson-Fix-symbol-leaks-on-Windows.patch
+++ b/subprojects/packagefiles/opus/0001-meson-Fix-symbol-leaks-on-Windows.patch
@@ -1,0 +1,75 @@
+From 5bdcf4afa6ed37ee449ba2cacffca8582e1fb377 Mon Sep 17 00:00:00 2001
+From: "L. E. Segovia" <amy@centricular.com>
+Date: Sun, 6 Jul 2025 13:05:29 -0300
+Subject: [PATCH] meson: Fix symbol leaks on Windows
+
+---
+ celt/meson.build | 2 +-
+ meson.build      | 2 +-
+ silk/meson.build | 2 +-
+ src/meson.build  | 6 +++++-
+ 4 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/celt/meson.build b/celt/meson.build
+index 370ea1fe..6d437901 100644
+--- a/celt/meson.build
++++ b/celt/meson.build
+@@ -50,7 +50,7 @@ if host_cpu_family in ['arm', 'aarch64'] and have_arm_intrinsics_or_asm
+ endif
+ 
+ celt_c_args = []
+-if host_system == 'windows'
++if host_machine.system() == 'windows' and get_option('default_library') == 'shared'
+   celt_c_args += ['-DDLL_EXPORT']
+ endif
+ 
+diff --git a/meson.build b/meson.build
+index 41f69353..254c9fe4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,6 +1,6 @@
+ project('opus', 'c',
+   version: run_command('meson/get-version.py', '--package-version', check: true).stdout().strip(),
+-  meson_version: '>=0.54.0',
++  meson_version: '>=1.3.0',
+   default_options: ['warning_level=2',
+                     'c_std=gnu99',
+                     'buildtype=debugoptimized'])
+diff --git a/silk/meson.build b/silk/meson.build
+index 70692372..59eaa16d 100644
+--- a/silk/meson.build
++++ b/silk/meson.build
+@@ -40,7 +40,7 @@ foreach intr_name : ['sse4_1', 'neon_intr']
+ endforeach
+ 
+ silk_c_args = []
+-if host_machine.system() == 'windows'
++if host_machine.system() == 'windows' and get_option('default_library') == 'shared'
+   silk_c_args += ['-DDLL_EXPORT']
+ endif
+ 
+diff --git a/src/meson.build b/src/meson.build
+index cc07ff06..bc0c5e51 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -15,12 +15,16 @@ opus_lib = library('opus',
+   opus_sources,
+   version: libversion,
+   darwin_versions: macosversion,
+-  c_args: opus_lib_c_args,
++  c_shared_args: opus_lib_c_args,
+   include_directories: opus_includes,
+   link_with: [celt_lib, silk_lib],
+   dependencies: libm,
+   install: true)
+ 
++if get_option('default_library') == 'both'
++  opus_lib = opus_lib.get_shared_library()
++endif
++
+ opus_dep = declare_dependency(link_with: opus_lib,
+   include_directories: opus_public_includes)
+ 
+-- 
+2.47.0.windows.2
+

--- a/subprojects/packagefiles/orc-0.4.38/0001-meson-fix-symbols-leaking-from-static-library-on-Win.patch
+++ b/subprojects/packagefiles/orc-0.4.38/0001-meson-fix-symbols-leaking-from-static-library-on-Win.patch
@@ -1,0 +1,118 @@
+From d385aaad799a667e23ab59386af8da8ae5102044 Mon Sep 17 00:00:00 2001
+From: "L. E. Segovia" <amy@centricular.com>
+Date: Sun, 6 Jul 2025 15:13:07 +0000
+Subject: [PATCH] meson: fix symbols leaking from static library on Windows
+
+Without ORC_STATIC_COMPILATION, these symbols will get treated as if
+they were compiled for a DLL. In turn, they will be forcibly
+(incorrectly) exported from any downstream DLL or EXE that consumes
+them.
+---
+ meson.build          |  2 +-
+ orc-test/meson.build | 20 +++++++++++++++-----
+ orc/meson.build      | 18 ++++++++++++++----
+ 3 files changed, 30 insertions(+), 10 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 6d03271..f5b84c7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,5 +1,5 @@
+ project ('orc', 'c', version : '0.4.38',
+-                     meson_version : '>= 0.55.0',
++                     meson_version : '>= 1.3.0',
+                      default_options : ['buildtype=debugoptimized',
+                                         'warning_level=1'] )
+ 
+diff --git a/orc-test/meson.build b/orc-test/meson.build
+index 20bcd63..e95cccd 100644
+--- a/orc-test/meson.build
++++ b/orc-test/meson.build
+@@ -3,20 +3,29 @@ orc_test_sources = ['orctest.c', 'orcarray.c', 'orcrandom.c', 'orcprofile.c']
+ 
+ install_headers(orc_test_headers, subdir : 'orc-' + orc_api + '/orc-test')
+ 
++orc_test_lib_args = orc_c_args + ['-DBUILDING_ORC_TEST']
++orc_test_static_cargs = ['-DORC_STATIC_COMPILATION']
++
+ orc_test_lib = library ('orc-test-' + orc_api,
+   orc_test_sources,
+   version : libversion,
+   soversion : soversion,
+   darwin_versions : osxversion,
+   include_directories : orc_inc,
+-  c_args : orc_c_args + ['-DBUILDING_ORC_TEST'],
++  c_args : orc_test_lib_args,
++  c_static_args : orc_test_lib_args + orc_test_static_cargs,
+   dependencies : [libm, orc_dep],
+   install : true)
+ 
++# https://github.com/mesonbuild/meson/pull/12632
+ orc_test_dep_cargs = []
+-
+-if get_option('default_library') == 'static'
+-  orc_test_dep_cargs += ['-DORC_STATIC_COMPILATION']
++if get_option('default_library') == 'both'
++  orc_test_dep_lib = orc_test_lib.get_shared_lib()
++else
++  orc_test_dep_lib = orc_test_lib
++  if get_option('default_library') == 'static'
++    orc_test_dep_cargs = orc_test_static_cargs
++  endif
+ endif
+ 
+ # pkg-config file
+@@ -28,4 +37,5 @@ pkg.generate(orc_test_lib,
+   libraries: [libm, orc_dep])
+ 
+ orc_test_dep = declare_dependency(include_directories : orc_inc,
+-  link_with : orc_test_lib)
++  link_with : orc_test_dep_lib,
++  compile_args : orc_test_dep_cargs)
+diff --git a/orc/meson.build b/orc/meson.build
+index 71e33e9..5a32893 100644
+--- a/orc/meson.build
++++ b/orc/meson.build
+@@ -113,25 +113,35 @@ if host_os != 'windows'
+   orc_dependencies += threads
+ endif
+ 
++orc_lib_args = orc_c_args + ['-DBUILDING_ORC']
++orc_static_cargs = ['-DORC_STATIC_COMPILATION']
++
+ orc_lib = library ('orc-' + orc_api,
+   orc_sources,
+   version : libversion,
+   soversion : soversion,
+   darwin_versions : osxversion,
+   include_directories : orc_inc,
+-  c_args : orc_c_args + ['-DBUILDING_ORC'],
++  c_args : orc_lib_args,
++  c_static_args : orc_lib_args + orc_static_cargs,
+   dependencies : orc_dependencies,
+   install : true)
+ 
++# https://github.com/mesonbuild/meson/pull/12632
+ orc_dep_cargs = []
+-if get_option('default_library') == 'static'
+-  orc_dep_cargs += ['-DORC_STATIC_COMPILATION']
++if get_option('default_library') == 'both'
++  orc_dep_lib = orc_lib.get_shared_lib()
++else
++  orc_dep_lib = orc_lib
++  if get_option('default_library') == 'static'
++    orc_dep_cargs = orc_static_cargs
++  endif
+ endif
+ 
+ orc_dep = declare_dependency(include_directories : orc_inc,
+                              dependencies : orc_dependencies,
+                              compile_args : orc_dep_cargs,
+-                             link_with : orc_lib)
++                             link_with : orc_dep_lib)
+ 
+ executable ('generate-bytecode',
+   'generate-bytecode.c',
+-- 
+2.47.0.windows.2
+


### PR DESCRIPTION
Both Orc and Opus enforce `__declspec(dllexport)` even though we're building them statically, so these symbols leak in the final binaries (whether DLLs or executable). These patches avoid that.

cc @nirbheek 