### PR TITLE
Fix Orc compilation crash by updating to Orc 0.4.41

### DIFF
--- a/subprojects/gst-plugins-good/sys/osxaudio/gstosxaudiodeviceprovider.c
+++ b/subprojects/gst-plugins-good/sys/osxaudio/gstosxaudiodeviceprovider.c
@@ -49,8 +49,8 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     );
 
 static GstOsxAudioDevice *gst_osx_audio_device_new (AudioDeviceID device_id,
-    const gchar * device_name, GstOsxAudioDeviceType type,
-    GstCoreAudio * core_audio);
+    const gchar * device_name, UInt32 transport_type,
+    GstOsxAudioDeviceType type, GstCoreAudio * core_audio);
 
 G_DEFINE_TYPE (GstOsxAudioDeviceProvider, gst_osx_audio_device_provider,
     GST_TYPE_DEVICE_PROVIDER);
@@ -93,7 +93,7 @@ gst_osx_audio_device_provider_init (GstOsxAudioDeviceProvider * provider)
 static GstOsxAudioDevice *
 gst_osx_audio_device_provider_probe_device (GstOsxAudioDeviceProvider *
     provider, AudioDeviceID device_id, const gchar * device_name,
-    GstOsxAudioDeviceType type)
+    UInt32 transport_type, GstOsxAudioDeviceType type)
 {
   GstOsxAudioDevice *device = NULL;
   GstCoreAudio *core_audio;
@@ -112,7 +112,7 @@ gst_osx_audio_device_provider_probe_device (GstOsxAudioDeviceProvider *
     goto done;
   }
 
-  device = gst_osx_audio_device_new (device_id, device_name, type, core_audio);
+  device = gst_osx_audio_device_new (device_id, device_name, transport_type, type, core_audio);
 
   gst_core_audio_close (core_audio);
 
@@ -276,21 +276,28 @@ gst_osx_audio_device_provider_probe_internal (GstOsxAudioDeviceProvider * self,
     AudioDeviceID * osx_devices, gint ndevices, GList ** devices)
 {
   for (int i = 0; i < ndevices; i++) {
+    UInt32 transport_type;
     char *device_name;
     GstOsxAudioDevice *device;
 
-    device_name = gst_core_audio_device_get_prop (osx_devices[i],
+    device_name = gst_core_audio_device_get_prop_str (osx_devices[i],
         kAudioObjectPropertyName);
     if (!device_name)
       continue;
 
+    transport_type = gst_core_audio_device_get_prop_uint32 (osx_devices[i],
+        kAudioDevicePropertyTransportType);
+    if (transport_type == UINT_MAX)
+      transport_type = kAudioDeviceTransportTypeUnknown;
+
     if (_audio_device_has_input (osx_devices[i])) {
       device =
           gst_osx_audio_device_provider_probe_device (self, osx_devices[i],
-          device_name, GST_OSX_AUDIO_DEVICE_TYPE_SOURCE);
+          device_name, transport_type, GST_OSX_AUDIO_DEVICE_TYPE_SOURCE);
       if (device) {
-        GST_DEBUG ("Input Device ID: %u Name: %s", (unsigned) osx_devices[i],
-            device_name);
+        GST_DEBUG ("Input Device ID: %u, Name: %s, Transport Type: %"
+            GST_FOURCC_FORMAT, (unsigned) osx_devices[i], device_name,
+            GST_FOURCC_ARGS (GUINT32_FROM_BE (transport_type)));
         gst_object_ref_sink (device);
         *devices = g_list_prepend (*devices, device);
       }
@@ -299,10 +306,11 @@ gst_osx_audio_device_provider_probe_internal (GstOsxAudioDeviceProvider * self,
     if (_audio_device_has_output (osx_devices[i])) {
       device =
           gst_osx_audio_device_provider_probe_device (self, osx_devices[i],
-          device_name, GST_OSX_AUDIO_DEVICE_TYPE_SINK);
+          device_name, transport_type, GST_OSX_AUDIO_DEVICE_TYPE_SINK);
       if (device) {
-        GST_DEBUG ("Output Device ID: %u Name: %s", (unsigned) osx_devices[i],
-            device_name);
+        GST_DEBUG ("Output Device ID: %u, Name: %s, Transport Type: %"
+            GST_FOURCC_FORMAT, (unsigned) osx_devices[i], device_name,
+            GST_FOURCC_ARGS (GUINT32_FROM_BE (transport_type)));
         gst_object_ref_sink (device);
         *devices = g_list_prepend (*devices, device);
       }
@@ -503,19 +511,25 @@ gst_osx_audio_device_create_element (GstDevice * device, const gchar * name)
 
 static GstOsxAudioDevice *
 gst_osx_audio_device_new (AudioDeviceID device_id, const gchar * device_name,
-    GstOsxAudioDeviceType type, GstCoreAudio * core_audio)
+    UInt32 transport_type, GstOsxAudioDeviceType type,
+    GstCoreAudio * core_audio)
 {
   GstOsxAudioDevice *gstdev;
   const gchar *element_name = NULL;
   const gchar *klass = NULL;
   GstCaps *template_caps, *caps;
   GstStructure *props = gst_structure_new_empty ("properties");
+  char *transport_name = g_strdup_printf ("%" GST_FOURCC_FORMAT,
+      GST_FOURCC_ARGS (GUINT32_FROM_BE (transport_type)));
 
   g_return_val_if_fail (device_id > 0, NULL);
   g_return_val_if_fail (device_name, NULL);
 
-  gst_structure_set (props, "is-default", G_TYPE_BOOLEAN,
-      core_audio->is_default, NULL);
+  gst_structure_set (props,
+      "is-default", G_TYPE_BOOLEAN, core_audio->is_default,
+      "transport", G_TYPE_STRING, transport_name, NULL);
+
+  g_free (transport_name);
 
   if (core_audio->unique_id != NULL) {
     gst_structure_set (props, "unique-id", G_TYPE_STRING,

--- a/subprojects/gst-plugins-good/sys/osxaudio/gstosxcoreaudio.c
+++ b/subprojects/gst-plugins-good/sys/osxaudio/gstosxcoreaudio.c
@@ -449,7 +449,7 @@ gst_core_audio_select_device (GstCoreAudio * core_audio)
 #ifndef HAVE_IOS
   if (core_audio->device_id != kAudioDeviceUnknown)
     core_audio->unique_id =
-        gst_core_audio_device_get_prop (core_audio->device_id,
+        gst_core_audio_device_get_prop_str (core_audio->device_id,
         kAudioDevicePropertyDeviceUID);
 #endif
 

--- a/subprojects/gst-plugins-good/sys/osxaudio/gstosxcoreaudiocommon.c
+++ b/subprojects/gst-plugins-good/sys/osxaudio/gstosxcoreaudiocommon.c
@@ -570,7 +570,7 @@ gst_core_audio_dump_channel_layout (AudioChannelLayout * channel_layout)
 
 #ifndef HAVE_IOS
 char *
-gst_core_audio_device_get_prop (AudioDeviceID device_id,
+gst_core_audio_device_get_prop_str (AudioDeviceID device_id,
     AudioObjectPropertyElement prop_id)
 {
   OSStatus status = noErr;
@@ -614,6 +614,31 @@ gst_core_audio_device_get_prop (AudioDeviceID device_id,
   CFRelease (prop_val);
 
 beach:
+  return result;
+}
+
+UInt32
+gst_core_audio_device_get_prop_uint32 (AudioDeviceID device_id,
+    AudioObjectPropertyElement prop_id)
+{
+  OSStatus status = noErr;
+  UInt32 propertySize = sizeof (UInt32);
+  UInt32 result = UINT32_MAX;
+
+  AudioObjectPropertyAddress propAddress = {
+    .mSelector = prop_id,
+    .mScope = kAudioObjectPropertyScopeGlobal,
+    .mElement = kAudioObjectPropertyElementMain,
+  };
+
+  /* Get the requested property */
+  status = AudioObjectGetPropertyData (device_id,
+      &propAddress, 0, NULL, &propertySize, &result);
+  if (status == noErr) {
+    GST_WARNING ("Failed to fetch property %" GST_FOURCC_FORMAT,
+        GST_FOURCC_ARGS (GUINT32_FROM_BE (prop_id)));
+  }
+
   return result;
 }
 #endif

--- a/subprojects/gst-plugins-good/sys/osxaudio/gstosxcoreaudiocommon.h
+++ b/subprojects/gst-plugins-good/sys/osxaudio/gstosxcoreaudiocommon.h
@@ -68,8 +68,10 @@ AudioChannelLabel gst_audio_channel_position_to_core_audio (GstAudioChannelPosit
 GstAudioChannelPosition gst_core_audio_channel_label_to_gst (AudioChannelLabel label, int channel, gboolean warn);
 
 #ifndef HAVE_IOS
-char * gst_core_audio_device_get_prop (AudioDeviceID device_id,
-                                       AudioObjectPropertyElement prop_id);
+char * gst_core_audio_device_get_prop_str (AudioDeviceID device_id,
+                                           AudioObjectPropertyElement prop_id);
+UInt32 gst_core_audio_device_get_prop_uint32 (AudioDeviceID device_id,
+                                              AudioObjectPropertyElement prop_id);
 #endif
 
 G_END_DECLS

--- a/subprojects/orc.wrap
+++ b/subprojects/orc.wrap
@@ -2,8 +2,7 @@
 directory=orc
 url=https://gitlab.freedesktop.org/gstreamer/orc.git
 push-url=git@gitlab.freedesktop.org:gstreamer/orc.git
-revision=0.4.38
-diff_files = orc-0.4.38/0001-meson-fix-symbols-leaking-from-static-library-on-Win.patch
+revision=0.4.41
 
 [provide]
 orc-0.4 = orc_dep

--- a/subprojects/packagefiles/orc-0.4.38/0001-meson-fix-symbols-leaking-from-static-library-on-Win.patch
+++ b/subprojects/packagefiles/orc-0.4.38/0001-meson-fix-symbols-leaking-from-static-library-on-Win.patch
@@ -18,8 +18,8 @@ index 6d03271..f5b84c7 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -1,5 +1,5 @@
- project ('orc', 'c', version : '0.4.38',
--                     meson_version : '>= 0.55.0',
+ project ('orc', 'c', version : '0.4.41',
+-                     meson_version : '>= 0.60.0',
 +                     meson_version : '>= 1.3.0',
                       default_options : ['buildtype=debugoptimized',
                                          'warning_level=1'] )
@@ -70,10 +70,10 @@ index 20bcd63..e95cccd 100644
 +  link_with : orc_test_dep_lib,
 +  compile_args : orc_test_dep_cargs)
 diff --git a/orc/meson.build b/orc/meson.build
-index 71e33e9..5a32893 100644
+index eb72be2..095d3b2 100644
 --- a/orc/meson.build
 +++ b/orc/meson.build
-@@ -113,25 +113,35 @@ if host_os != 'windows'
+@@ -113,22 +113,32 @@ if host_os != 'windows'
    orc_dependencies += threads
  endif
  
@@ -110,9 +110,6 @@ index 71e33e9..5a32893 100644
                               compile_args : orc_dep_cargs,
 -                             link_with : orc_lib)
 +                             link_with : orc_dep_lib)
- 
- executable ('generate-bytecode',
-   'generate-bytecode.c',
 -- 
 2.47.0.windows.2
 


### PR DESCRIPTION
This was filed against the tag [2025-06-25_1.24.8](https://github.com/terrylowry/gstreamer/releases/tag/2025-06-25_1.24.8) for testing - @nirbheek, feel free to rebase it against `gigroom` if that's the better approach.